### PR TITLE
Locales fix

### DIFF
--- a/idrive/build/Dockerfile
+++ b/idrive/build/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:24.04
 
 # Install packages
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
+      locales-all \
       tzdata \
       vim \
       unzip \


### PR DESCRIPTION
Adds ability to use environment variables like:
LANG=en_EN.UTF-8
LC_ALL=en_EN.UTF-8
It's necessary to correctly render file and folder names in iDrive UI and backup files and folders named in different than English languages.