### PR TITLE
Update actions off deprecated Node 12/16/20 runtimes

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check for new iDrive version
         if: github.event_name != 'push'
         id: check-version
-        uses: tyriis/docker-image-tag-exists@v2.1.0
+        uses: tyriis/docker-image-tag-exists@v2026.6.0
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}

--- a/.github/workflows/update-description.yml
+++ b/.github/workflows/update-description.yml
@@ -16,10 +16,10 @@ jobs:
     # steps to perform in job
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.2
 
       - name: Update dockerhub repo description
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Three actions still declared runtimes GitHub has deprecated, which produces warnings on every run:

  tyriis/docker-image-tag-exists   v2.1.0 -> v2026.6.0  (was node20)
  actions/checkout                 v3     -> v6.0.2     (was node16)
  peter-evans/dockerhub-description v2    -> v5.0.0     (was node12)

Inputs and outputs are unchanged for all three as used here: docker-image-tag-exists keeps the same registry/repository/tag inputs and the same `found` / `not found` output, and dockerhub-description v5 is a superset of v2's inputs. No step logic needed changing.

Versions use the same exact-pin style already used elsewhere in build-and-publish.yml.